### PR TITLE
Mark code_executer function as unsafe

### DIFF
--- a/karamelapp/src/main.rs
+++ b/karamelapp/src/main.rs
@@ -46,7 +46,7 @@ döngü i = 0, i < 10, i++:
     };
 
     
-    let result = karamellib::vm::executer::code_executer(parameters);
+    let result = unsafe { karamellib::vm::executer::code_executer(parameters) };
     match result.executed {
         true => println!("Success"),
         false => println!("Fail")

--- a/karamellib/src/vm/executer.rs
+++ b/karamellib/src/vm/executer.rs
@@ -55,7 +55,7 @@ pub fn get_execution_path<T: Borrow<ExecutionSource>>(source: T) -> ExecutionPat
     }
 }
 
-pub fn code_executer(parameters: ExecutionParameters) -> ExecutionStatus {
+pub unsafe fn code_executer(parameters: ExecutionParameters) -> ExecutionStatus {
     let mut status = ExecutionStatus::default();
     match log::set_logger(&CONSOLE_LOGGER) {
         Ok(_) => {

--- a/karamellib/tests/test_executers.rs
+++ b/karamellib/tests/test_executers.rs
@@ -59,7 +59,7 @@ mod tests {
                                 dump_memory: false
                             };
 
-                            let result = executer::code_executer(parameters);
+                            let result = unsafe { executer::code_executer(parameters) };
                             match result.compiled && result.executed {
                                 true => {
                                     if !is_pass {

--- a/karamelweb/src/lib.rs
+++ b/karamelweb/src/lib.rs
@@ -24,7 +24,7 @@ pub fn execute_code(name: &str) -> Object {
         dump_memory: true
     };
 
-    let result = karamellib::vm::executer::code_executer(parameters);
+    let result = unsafe { karamellib::vm::executer::code_executer(parameters) };
     match result.compiled && result.executed {
         true => {
             Reflect::set(response.as_ref(), status_ref.as_ref(), JsValue::from_bool(true).as_ref()).unwrap();


### PR DESCRIPTION
https://github.com/erhanbaris/karamel/blob/d11e8cbb7018aa80322a782c64519ca0e6ecdcaf/karamellib/src/vm/executer.rs#L58-L164
```rust
    let data = ExecutionSource::File("".to_string());
    let param = ExecutionParameters{
                    source: data, 
                    return_opcode:true,
                    return_output:true, 
                    dump_opcode:true, 
                    dump_memory:false};
    let _ = code_executer(param);
``` 
@erhanbaris Hello, in the above test case, the function has a memory leak.
`SUMMARY: Addresssanitizer:3003 byte(s) leaked in 46 allocation(s).
INFO: to ignore leaks on libFuzzer side use -detect leaks=0.`
Marking them unsafe also means that callers must make sure they know what they're doing.